### PR TITLE
Fix build.zig addCSourceFiles invocation for latest zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,7 +26,10 @@ pub fn build(b: *std.Build) !void {
         "-DHAVE_STDDEF_H",
         "-DZ_HAVE_UNISTD_H",
     });
-    lib.addCSourceFiles(srcs, flags.items);
+    lib.addCSourceFiles(.{
+        .flags = flags.items,
+        .files = srcs,
+    });
 
     b.installArtifact(lib);
 }


### PR DESCRIPTION
Fixes a breaking change in the zig build system, which was introduced here:

https://github.com/ziglang/zig/pull/17420/files